### PR TITLE
feat: allow passing headers as an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Works in tandem with:
 | federated   | false   | no                     |
 | subgraph    |         | no, if federated false |
 | server      |         | apollo server url      |
+| headers     |         | no, JSON if provided   |
 
 ## outputs
 | name   | description                |
@@ -34,6 +35,7 @@ jobs:
         federated: true
         subgraph: products
         server: http://apollo:3000/
+        headers: {"token": "s3cr3t"}
       env:
         APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   server:
     description: 'apollo server url'
     required: true
+  headers:
+    description: 'headers to include in introspection request, as JSON'
+    required: false
 outputs:
   schema:
     description: 'base64 encoded fetched SDL'

--- a/index.js
+++ b/index.js
@@ -34,10 +34,15 @@ const setOutput = (schema) => {
 const parseHeaders = (rawHeaders) => {
   if (rawHeaders === '') return []
 
-  const headers = JSON.parse(rawHeaders)
-  return Object.entries(headers).reduce((acc, header) => {
-    return acc.concat(['--header', header.join(':')])
-  }, [])
+  try {
+    const headers = JSON.parse(rawHeaders)
+    return Object.entries(headers).reduce((acc, header) => {
+      return acc.concat(['--header', header.join(':')])
+    }, [])
+  } catch(error) {
+    core.error('Failed to parse headers input, is it valid JSON?')
+    throw error
+  }
 }
 
 const getInput = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rover-introspect",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/DanielSinclair/rover-introspect#readme",
   "dependencies": {
     "@actions/artifact": "^0.5.2",
-    "@actions/core": "^1.5.0",
+    "@actions/core": "^1.6.0",
     "@actions/exec": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,12 @@
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.4.0.tgz#cf2e6ee317e314b03886adfeb20e448d50d6e524"
   integrity sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg==
 
-"@actions/core@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.5.0.tgz#885b864700001a1b9a6fba247833a036e75ad9d3"
-  integrity sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ==
+"@actions/core@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.6.0.tgz#0568e47039bfb6a9170393a73f3b7eb3b22462cb"
+  integrity sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==
+  dependencies:
+    "@actions/http-client" "^1.0.11"
 
 "@actions/exec@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Sometimes when making a request to a GraphQL endpoint, you need to pass headers for the request to be successful. A common example is token headers used for authorization.

This PR adds a new input, `headers`, which accepts a JSON string to represent any headers that should be included in the introspection request.

Example job config:
```yml
- uses: danielsinclair/rover-introspect
      with:
        federated: true
        subgraph: products
        server: http://apollo:3000/
        headers: {"token": "s3cr3t", "machine_name": "localhost" }
      env:
        APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
```

Resulting rover request:
```sh
rover subgraph introspect http://apollo:3000/ --header token:s3cr3t --header machine_name:localhost
```